### PR TITLE
Add CLI text/voice chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# AI Assistant with 3D Anime Model
+# AI Assistant with 3D Anime Model
 
 ## Setup Instructions
 
@@ -11,15 +11,15 @@
    - Add your API keys
 
 3. **Install Python Dependencies**
-   `ash
+   ash
    cd AI_Assistant_Project
    python -m venv venv
-   .\venv\Scripts\activate
+   .\\venv\\Scripts\\activate
    pip install -r requirements.txt
    `
 
 4. **Install Node Dependencies**
-   `ash
+   ash
    cd src/electron
    npm install
    `
@@ -31,17 +31,29 @@
 ## Running the Project
 
 1. Start the Python backend:
-   `ash
+   ash
    python src/python/main.py
    `
 
 2. Open Unity project in src/unity
 
 3. Run Electron app:
-   `ash
+   ash
    cd src/electron
    npm start
    `
+
+### Running Without a GUI
+
+For a simple text or voice chat interface without Unity or Electron, run:
+
+```
+python src/python/cli_chat.py
+```
+
+Follow the prompts to talk by typing or using your microphone. Responses are
+printed in the terminal and, when an ElevenLabs API key is configured, also
+spoken aloud.
 
 ## Project Structure
 - /src/python - AI backend and voice processing

--- a/src/python/cli_chat.py
+++ b/src/python/cli_chat.py
@@ -1,0 +1,70 @@
+import os
+import openai
+import speech_recognition as sr
+from dotenv import load_dotenv
+from elevenlabs import generate, play, set_api_key
+
+
+def main():
+    """Simple CLI for interacting with the AI assistant using text or voice."""
+    load_dotenv()
+
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    eleven_key = os.getenv("ELEVENLABS_API_KEY")
+    voice_id = os.getenv("TTS_VOICE_ID", "default")
+
+    if eleven_key:
+        set_api_key(eleven_key)
+
+    recognizer = sr.Recognizer()
+    microphone = sr.Microphone()
+    conversation = []
+
+    def ask_openai(prompt: str) -> str:
+        conversation.append({"role": "user", "content": prompt})
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=conversation,
+            temperature=0.7,
+            max_tokens=150,
+        )
+        answer = response.choices[0].message.content
+        conversation.append({"role": "assistant", "content": answer})
+        return answer
+
+    def speak(text: str) -> None:
+        if not eleven_key:
+            return
+        audio = generate(text=text, voice=voice_id, model="eleven_monolingual_v1")
+        play(audio)
+
+    while True:
+        mode = input("Enter 't' for text, 'v' for voice, or 'q' to quit: ").strip().lower()
+        if mode == "q":
+            break
+        if mode == "v":
+            print("Listening...")
+            with microphone as source:
+                recognizer.adjust_for_ambient_noise(source)
+                audio = recognizer.listen(source)
+            try:
+                user_text = recognizer.recognize_google(audio)
+                print(f"You said: {user_text}")
+            except sr.UnknownValueError:
+                print("Could not understand audio.")
+                continue
+        else:
+            user_text = input("You: ")
+
+        try:
+            reply = ask_openai(user_text)
+        except Exception as exc:
+            print(f"Error from OpenAI: {exc}")
+            continue
+
+        print(f"Assistant: {reply}")
+        speak(reply)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add cli_chat.py for text or voice interaction without a GUI
- document new CLI mode in README

## Testing
- `python -m py_compile src/python/cli_chat.py src/python/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb3982ec832cab7379f117c4d22b