### PR TITLE
Only open DevTools in development mode

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -11,8 +11,10 @@ function createWindow () {
   })
 
   mainWindow.loadFile('index.html')
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools()
+  // Open the DevTools in development mode.
+  if (process.env.NODE_ENV === 'development') {
+    mainWindow.webContents.openDevTools()
+  }
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- Wrap `webContents.openDevTools()` with a `NODE_ENV === 'development'` check so production builds don't show DevTools

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9feba5d94832c8ec242a95c95270b