### PR TITLE
Remove BOM and redundant asyncio requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-﻿openai==1.3.0
+openai==1.3.0
 speechrecognition==3.10.0
 pyaudio==0.2.11
 websockets==11.0.3
@@ -9,5 +9,4 @@ opencv-python==4.8.1.78
 pillow==10.1.0
 pydantic==2.5.0
 python-dotenv==1.0.0
-asyncio==3.4.3
 aiohttp==3.9.1


### PR DESCRIPTION
## Summary
- Remove UTF-8 BOM from requirements file
- Drop unnecessary asyncio dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ⚠️ `python -m pip index versions openai` (proxy blocked)

------
https://chatgpt.com/codex/tasks/task_e_68a9fea9b3c0832c98d93b60a16108db