### PR TITLE
Store event loop for threaded voice commands

### DIFF
--- a/src/python/main.py
+++ b/src/python/main.py
@@ -41,6 +41,9 @@ if ELEVENLABS_API_KEY:
 
 class AIAssistant:
     def __init__(self):
+        # Store reference to the main asyncio event loop so worker threads
+        # can safely submit coroutines to it later.
+        self.loop = asyncio.get_event_loop()
         self.recognizer = sr.Recognizer()
         self.microphone = sr.Microphone()
         self.is_listening = False
@@ -129,7 +132,7 @@ class AIAssistant:
                         if command:
                             asyncio.run_coroutine_threadsafe(
                                 self.process_voice_command(command),
-                                asyncio.get_event_loop()
+                                self.loop
                             )
                             
                 except sr.UnknownValueError:


### PR DESCRIPTION
## Summary
- Capture main asyncio event loop during `AIAssistant` initialization to share across threads.
- Use stored loop with `asyncio.run_coroutine_threadsafe` for voice command handling.

## Testing
- `python -m py_compile src/python/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9feaf2650832caad2a40b3d11e1ab