### PR TITLE
Use temporary audio files

### DIFF
--- a/src/python/main.py
+++ b/src/python/main.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime
 import speech_recognition as sr
 import websockets
@@ -231,19 +232,31 @@ class AIAssistant:
                     model="eleven_monolingual_v1"
                 )
                 
-                # Save audio temporarily
-                audio_path = "temp_audio.mp3"
-                with open(audio_path, 'wb') as f:
-                    f.write(audio)
-                    
+                # Save audio to a unique temporary file
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as tmp_file:
+                    tmp_file.write(audio)
+                    audio_path = tmp_file.name
+
                 # Send audio path to client
                 await self.broadcast({
                     "type": "audio",
                     "path": audio_path
                 })
-                
+
+                # Schedule deletion of the temporary file
+                asyncio.create_task(self.delete_temp_file(audio_path))
+
             except Exception as e:
                 logger.error(f"TTS generation error: {e}")
+
+    async def delete_temp_file(self, path, delay: int = 30):
+        """Remove a temporary file after an optional delay."""
+        await asyncio.sleep(delay)
+        try:
+            os.remove(path)
+            logger.info(f"Deleted temporary audio file: {path}")
+        except OSError as e:
+            logger.error(f"Error deleting temp audio file {path}: {e}")
                 
 async def main():
     """Main application entry point"""

--- a/src/unity/CharacterController.cs
+++ b/src/unity/CharacterController.cs
@@ -256,8 +256,11 @@ public class CharacterController : MonoBehaviour
     {
         if (audioSource == null) yield break;
 
+        // Ensure the path is a valid file URL
+        string url = audioPath.StartsWith("file://") ? audioPath : $"file://{audioPath}";
+
         // Load audio file
-        using (UnityWebRequest www = UnityWebRequestMultimedia.GetAudioClip($"file:///{audioPath}", AudioType.MPEG))
+        using (UnityWebRequest www = UnityWebRequestMultimedia.GetAudioClip(url, AudioType.MPEG))
         {
             yield return www.SendWebRequest();
 


### PR DESCRIPTION
## Summary
- write ElevenLabs audio to uniquely named temporary files
- clean up temporary audio files asynchronously
- load audio from file URLs in Unity to support temp paths

## Testing
- `pytest`
- `python -m py_compile src/python/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9feb2bbc0832c94146427d5993752