### PR TITLE
feat: add pluggable AI provider module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,15 @@ TTS_VOICE_ID=default
 
 # Model Settings
 MODEL_PATH=assets/models/character.model3.json
+
+# AI Provider Settings
+# Options: openai, gemini, mcp
+AI_PROVIDER=openai
+OPENAI_API_BASE=
+OPENAI_MODEL=gpt-3.5-turbo
+MCP_API_KEY=
+MCP_API_BASE=
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-pro
+MODEL_TEMPERATURE=0.7
+MODEL_MAX_TOKENS=150

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 2. **Configure API Keys**
    - Copy .env.example to .env
    - Add your API keys
+   - Choose the AI provider with `AI_PROVIDER` (`openai`, `gemini`, or `mcp`)
 
 3. **Install Python Dependencies**
    ash
@@ -54,6 +55,15 @@ python src/python/cli_chat.py
 Follow the prompts to talk by typing or using your microphone. Responses are
 printed in the terminal and, when an ElevenLabs API key is configured, also
 spoken aloud.
+
+## AI Provider Configuration
+
+The assistant can use different AI backends. Set the `AI_PROVIDER` value in
+your `.env` file to choose between:
+
+- `openai` (default) – uses `OPENAI_API_KEY`
+- `gemini` – requires `GEMINI_API_KEY`
+- `mcp` – uses an OpenAI-compatible endpoint with `MCP_API_KEY` and `MCP_API_BASE`
 
 ## Project Structure
 - /src/python - AI backend and voice processing

--- a/requirements-no-audio.txt
+++ b/requirements-no-audio.txt
@@ -10,3 +10,5 @@ pydantic==2.5.0
 python-dotenv==1.0.0
 asyncio==3.4.3
 aiohttp==3.9.1
+
+google-generativeai>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ pydantic==2.5.0
 python-dotenv==1.0.0
 asyncio==3.4.3
 aiohttp==3.9.1
+
+google-generativeai>=0.3.0

--- a/src/python/ai_provider.py
+++ b/src/python/ai_provider.py
@@ -1,0 +1,71 @@
+import os
+import openai
+
+try:
+    import google.generativeai as genai
+except Exception:
+    genai = None
+
+
+class AIProvider:
+    """Selects and interacts with different AI providers."""
+
+    def __init__(self) -> None:
+        self.provider = os.getenv("AI_PROVIDER", "openai").lower()
+        self.temperature = float(os.getenv("MODEL_TEMPERATURE", "0.7"))
+        self.max_tokens = int(os.getenv("MODEL_MAX_TOKENS", "150"))
+
+        if self.provider in ("openai", "chatgpt"):
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise ValueError("OPENAI_API_KEY is not set")
+            openai.api_key = api_key
+            base = os.getenv("OPENAI_API_BASE")
+            if base:
+                openai.api_base = base
+            self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+        elif self.provider == "mcp":
+            api_key = os.getenv("MCP_API_KEY")
+            base = os.getenv("MCP_API_BASE")
+            if not api_key or not base:
+                raise ValueError("MCP_API_KEY and MCP_API_BASE must be set for MCP provider")
+            openai.api_key = api_key
+            openai.api_base = base
+            self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+        elif self.provider == "gemini":
+            if genai is None:
+                raise ImportError("google-generativeai package is required for Gemini provider")
+            api_key = os.getenv("GEMINI_API_KEY")
+            if not api_key:
+                raise ValueError("GEMINI_API_KEY is not set")
+            genai.configure(api_key=api_key)
+            model_name = os.getenv("GEMINI_MODEL", "gemini-pro")
+            self.model = genai.GenerativeModel(model_name)
+
+        else:
+            raise ValueError(f"Unsupported AI_PROVIDER '{self.provider}'")
+
+    def chat_completion(self, messages):
+        """Return a chat completion from the configured provider."""
+        if self.provider in ("openai", "chatgpt", "mcp"):
+            response = openai.ChatCompletion.create(
+                model=self.model,
+                messages=messages,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+            return response.choices[0].message.content
+
+        elif self.provider == "gemini":
+            history = []
+            for msg in messages[:-1]:
+                role = "user" if msg["role"] == "user" else "model"
+                history.append({"role": role, "parts": [msg["content"]]})
+            chat = self.model.start_chat(history=history)
+            result = chat.send_message(messages[-1]["content"])
+            return result.text
+
+        else:
+            raise ValueError(f"Unsupported provider '{self.provider}'")

--- a/src/python/cli_chat.py
+++ b/src/python/cli_chat.py
@@ -1,34 +1,30 @@
 import os
-import openai
 import speech_recognition as sr
 from dotenv import load_dotenv
 from elevenlabs import generate, play, set_api_key
+
+from ai_provider import AIProvider
 
 
 def main():
     """Simple CLI for interacting with the AI assistant using text or voice."""
     load_dotenv()
 
-    openai.api_key = os.getenv("OPENAI_API_KEY")
     eleven_key = os.getenv("ELEVENLABS_API_KEY")
     voice_id = os.getenv("TTS_VOICE_ID", "default")
 
     if eleven_key:
         set_api_key(eleven_key)
 
+    provider = AIProvider()
+
     recognizer = sr.Recognizer()
     microphone = sr.Microphone()
     conversation = []
 
-    def ask_openai(prompt: str) -> str:
+    def ask_ai(prompt: str) -> str:
         conversation.append({"role": "user", "content": prompt})
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=conversation,
-            temperature=0.7,
-            max_tokens=150,
-        )
-        answer = response.choices[0].message.content
+        answer = provider.chat_completion(conversation)
         conversation.append({"role": "assistant", "content": answer})
         return answer
 
@@ -57,9 +53,9 @@ def main():
             user_text = input("You: ")
 
         try:
-            reply = ask_openai(user_text)
+            reply = ask_ai(user_text)
         except Exception as exc:
-            print(f"Error from OpenAI: {exc}")
+            print(f"Error from AI provider: {exc}")
             continue
 
         print(f"Assistant: {reply}")

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -11,8 +11,8 @@ from datetime import datetime
 import speech_recognition as sr
 import websockets
 from dotenv import load_dotenv
-import openai
 from elevenlabs import generate, set_api_key
+from ai_provider import AIProvider
 import threading
 import queue
 import logging
@@ -28,16 +28,15 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Configuration
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 ELEVENLABS_API_KEY = os.getenv('ELEVENLABS_API_KEY')
 WEBSOCKET_PORT = int(os.getenv('WEBSOCKET_PORT', 8080))
 VOICE_ACTIVATION_KEYWORD = os.getenv('VOICE_ACTIVATION_KEYWORD', 'Hey Assistant').lower()
 TTS_VOICE_ID = os.getenv('TTS_VOICE_ID', 'default')
 
-# Set API keys
-openai.api_key = OPENAI_API_KEY
+# Set API key for ElevenLabs
 if ELEVENLABS_API_KEY:
     set_api_key(ELEVENLABS_API_KEY)
+
 
 class AIAssistant:
     def __init__(self):
@@ -47,51 +46,52 @@ class AIAssistant:
         self.clients = set()
         self.message_queue = queue.Queue()
         self.conversation_history = []
-        
+        self.ai_provider = AIProvider()
+
     async def handle_client(self, websocket, path):
         """Handle WebSocket client connections"""
         self.clients.add(websocket)
         logger.info(f"Client connected: {websocket.remote_address}")
-        
+
         try:
             await websocket.send(json.dumps({
                 "type": "connection",
-                "message": "Connected to AI Assistant"
+                "message": "Connected to AI Assistant",
             }))
-            
+
             async for message in websocket:
                 data = json.loads(message)
                 await self.process_client_message(data, websocket)
-                
+
         except websockets.exceptions.ConnectionClosed:
             pass
         finally:
             self.clients.remove(websocket)
             logger.info(f"Client disconnected: {websocket.remote_address}")
-            
+
     async def process_client_message(self, data, websocket):
         """Process messages from Unity/Electron client"""
         message_type = data.get('type')
-        
+
         if message_type == 'text_input':
             # Process text input from UI
             text = data.get('text')
             response = await self.get_ai_response(text)
             await self.send_response(response)
-            
+
         elif message_type == 'start_listening':
             self.start_voice_recognition()
-            
+
         elif message_type == 'stop_listening':
             self.stop_voice_recognition()
-            
+
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
             await asyncio.gather(
                 *[client.send(json.dumps(message)) for client in self.clients]
             )
-            
+
     def start_voice_recognition(self):
         """Start continuous voice recognition"""
         if not self.is_listening:
@@ -100,107 +100,100 @@ class AIAssistant:
             thread.daemon = True
             thread.start()
             logger.info("Voice recognition started")
-            
+
     def stop_voice_recognition(self):
         """Stop voice recognition"""
         self.is_listening = False
         logger.info("Voice recognition stopped")
-        
+
     def voice_recognition_loop(self):
         """Continuous voice recognition loop"""
         with self.microphone as source:
             self.recognizer.adjust_for_ambient_noise(source)
-            
+
         while self.is_listening:
             try:
                 with self.microphone as source:
                     # Listen for audio with timeout
                     audio = self.recognizer.listen(source, timeout=1, phrase_time_limit=5)
-                    
+
                 try:
                     # Recognize speech using Google Speech Recognition
                     text = self.recognizer.recognize_google(audio)
                     logger.info(f"Recognized: {text}")
-                    
+
                     # Check for activation keyword
                     if VOICE_ACTIVATION_KEYWORD in text.lower():
-                        # Remove activation keyword and process
                         command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
                         if command:
                             asyncio.run_coroutine_threadsafe(
                                 self.process_voice_command(command),
-                                asyncio.get_event_loop()
+                                asyncio.get_event_loop(),
                             )
-                            
+
                 except sr.UnknownValueError:
                     pass  # Could not understand audio
                 except sr.RequestError as e:
                     logger.error(f"Speech recognition error: {e}")
-                    
+
             except sr.WaitTimeoutError:
                 pass  # Timeout, continue listening
-                
+
     async def process_voice_command(self, command):
         """Process voice command"""
         logger.info(f"Processing command: {command}")
-        
+
         # Send listening indicator
         await self.broadcast({
             "type": "status",
             "status": "processing",
-            "message": "Processing your request..."
+            "message": "Processing your request...",
         })
-        
+
         # Get AI response
         response = await self.get_ai_response(command)
         await self.send_response(response)
-        
+
     async def get_ai_response(self, user_input):
-        """Get response from OpenAI"""
+        """Get response from the configured AI provider"""
         try:
             # Add to conversation history
             self.conversation_history.append({"role": "user", "content": user_input})
-            
+
             # Keep conversation history manageable
             if len(self.conversation_history) > 10:
                 self.conversation_history = self.conversation_history[-10:]
-            
-            # Get response from OpenAI
-            response = await asyncio.to_thread(
-                openai.ChatCompletion.create,
-                model="gpt-3.5-turbo",
-                messages=[
+
+            ai_response = await asyncio.to_thread(
+                self.ai_provider.chat_completion,
+                [
                     {"role": "system", "content": "You are a friendly and helpful AI assistant with an anime personality. Be enthusiastic and supportive."},
-                    *self.conversation_history
-                ],
-                temperature=0.7,
-                max_tokens=150
+                    *self.conversation_history,
+                ]
             )
-            
-            ai_response = response.choices[0].message.content
-            
+
             # Add to conversation history
             self.conversation_history.append({"role": "assistant", "content": ai_response})
-            
+
             # Analyze emotion for animation
             emotion = self.analyze_emotion(ai_response)
-            
+
             return {
                 "text": ai_response,
-                "emotion": emotion
+                "emotion": emotion,
             }
-            
+
         except Exception as e:
             logger.error(f"Error getting AI response: {e}")
             return {
                 "text": "I'm sorry, I encountered an error processing your request.",
-                "emotion": "neutral"
+                "emotion": "neutral",
             }
-            
+
     def analyze_emotion(self, text):
         """Simple emotion analysis for animation triggers"""
         text_lower = text.lower()
-        
+
         if any(word in text_lower for word in ['happy', 'great', 'wonderful', 'awesome', 'excited']):
             return 'happy'
         elif any(word in text_lower for word in ['sorry', 'sad', 'unfortunately']):
@@ -211,55 +204,52 @@ class AIAssistant:
             return 'surprised'
         else:
             return 'neutral'
-            
+
     async def send_response(self, response):
         """Send response to clients and generate TTS"""
-        # Send text and emotion to Unity for animation
         await self.broadcast({
             "type": "response",
             "text": response['text'],
             "emotion": response['emotion'],
-            "timestamp": datetime.now().isoformat()
+            "timestamp": datetime.now().isoformat(),
         })
-        
-        # Generate TTS if ElevenLabs is configured
+
         if ELEVENLABS_API_KEY:
             try:
                 audio = generate(
                     text=response['text'],
                     voice=TTS_VOICE_ID,
-                    model="eleven_monolingual_v1"
+                    model="eleven_monolingual_v1",
                 )
-                
-                # Save audio temporarily
+
                 audio_path = "temp_audio.mp3"
                 with open(audio_path, 'wb') as f:
                     f.write(audio)
-                    
-                # Send audio path to client
+
                 await self.broadcast({
                     "type": "audio",
-                    "path": audio_path
+                    "path": audio_path,
                 })
-                
+
             except Exception as e:
                 logger.error(f"TTS generation error: {e}")
-                
+
+
 async def main():
     """Main application entry point"""
     assistant = AIAssistant()
-    
-    # Start WebSocket server
+
     logger.info(f"Starting WebSocket server on port {WEBSOCKET_PORT}")
     async with websockets.serve(assistant.handle_client, "localhost", WEBSOCKET_PORT):
         logger.info("AI Assistant backend is running...")
-        
+
         # Start voice recognition by default
         assistant.start_voice_recognition()
-        
+
         # Keep the server running
         await asyncio.Future()
-        
+
+
 if __name__ == "__main__":
     try:
         asyncio.run(main())


### PR DESCRIPTION
## Summary
- add AIProvider module to switch between OpenAI, Gemini, or MCP backends
- update CLI and backend to use provider
- document new environment variables and dependency

## Testing
- `python -m py_compile src/python/ai_provider.py src/python/cli_chat.py src/python/main.py`
- `pip install google-generativeai==0.3.2` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa031e1c54832c9b17d1b5ff184c14