### PR TITLE
⚡ Bolt: [O(N) Latency Fix for Broadcasts]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-02 - O(N) Latency Fix in WebSocket Broadcasts
+**Learning:** In asynchronous applications handling multiple WebSocket clients, performing sequential external API calls (e.g., OpenAI or TTS) for each client in a `for` loop introduces an O(N) latency bottleneck, causing significant delays for clients later in the loop. The `asyncio` event loop is blocked waiting for each external call to finish.
+**Action:** Always use `asyncio.gather` (or similar concurrency mechanisms) when broadcasting messages that require individualized external API calls or expensive async operations, ensuring O(1) latency relative to the number of connected clients.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -165,9 +165,15 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+            # Use asyncio.gather to avoid O(N) performance bottleneck for multiple clients
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            if self.clients:
+                await asyncio.gather(
+                    *[process_for_client(client) for client in self.clients]
+                )
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
💡 What: Replaced sequential `for client in list(self.clients):` processing with `asyncio.gather` in `process_voice_command`.
🎯 Why: Calling the OpenAI API and generating TTS audio synchronously for every client inside the broadcast loop was creating an O(N) performance bottleneck.
📊 Impact: Expected to reduce processing latency to O(1) latency relative to the number of active client connections.
🔬 Measurement: Can be verified by connecting multiple clients, sending a voice broadcast, and measuring the time it takes for all clients to receive a response.

---
*PR created automatically by Jules for task [150581544038699917](https://jules.google.com/task/150581544038699917) started by @hana89088*