### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Avoid Sequential Execution in WebSocket Broadcasts
+
+**Learning:** In backend operations that require sending distinct external API calls for multiple connected clients (like generating a unique AI response or custom TTS audio for each WebSocket client), iterating sequentially creates an O(N) latency bottleneck. As client count increases, the time to complete a single user action degrades severely.
+
+**Action:** Whenever handling operations across multiple clients that perform external API calls or other non-trivial async tasks, execute them concurrently using `asyncio.gather()`. This maintains an O(1) time complexity relative to the number of clients, bounded only by the underlying connection pool/rate limits.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -165,9 +165,14 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            clients = list(self.clients)
+            if clients:
+                await asyncio.gather(*(process_for_client(client) for client in clients))
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
## 💡 What
Refactored the `process_voice_command` function in `src/python/main.py` to use `asyncio.gather()` instead of a sequential `for` loop when broadcasting responses to multiple clients. I also added a critical learning entry to `.jules/bolt.md`.

## 🎯 Why
Previously, the backend iterated through connected clients sequentially, making an external OpenAI API call and a TTS ElevenLabs call for each. This created an O(N) latency bottleneck where the Nth client had to wait for the previous N-1 clients' API calls to finish. The new concurrent execution resolves this blocking behavior.

## 📊 Impact
Reduces broadcast latency from O(N) to O(1) relative to the number of active clients. For instance, if generating a response takes 2 seconds, broadcasting to 5 clients previously took ~10 seconds. Now it takes ~2 seconds, constrained only by concurrent connection limits.

## 🔬 Measurement
Start the backend and connect multiple frontend clients. Send a voice broadcast command. Observe the `status` logs and timestamp metrics for each client. They should now receive their customized AI responses almost simultaneously instead of in a staggered sequence.

---
*PR created automatically by Jules for task [14101288779108203700](https://jules.google.com/task/14101288779108203700) started by @hana89088*