### PR TITLE
⚡ Bolt: [performance improvement] Concurrent processing for WebSocket broadcasts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-02 - O(N) Latency Bottleneck in WebSocket Broadcasts
+**Learning:** In the Python backend, broadcasting voice commands to multiple clients triggers individual OpenAI and ElevenLabs API calls. Performing these sequentially in a `for` loop causes O(N) latency, severely degrading performance for later clients.
+**Action:** Use `asyncio.gather` to process external API calls concurrently across all clients, restoring O(1) latency relative to the connection count.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -165,9 +165,15 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+
+            async def process_and_send(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            if self.clients:
+                await asyncio.gather(
+                    *[process_and_send(client) for client in self.clients]
+                )
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
💡 What: Replaced the sequential `for` loop in `process_voice_command` with concurrent execution using `asyncio.gather()`.

🎯 Why: In the Python backend, broadcasting voice commands to multiple clients triggered individual OpenAI and ElevenLabs API calls. Processing these sequentially in a `for` loop caused O(N) latency, severely degrading performance for clients handled later in the loop.

📊 Impact: Restores O(1) latency relative to the connection count during broadcasts. By processing external API calls concurrently, the total broadcast time is now bounded by the slowest individual request rather than the sum of all requests.

🔬 Measurement: Start the backend, connect multiple clients simultaneously (e.g. 5+ connections), send a voice command, and measure the arrival time difference of responses among the clients. All connected clients should now receive the response almost simultaneously instead of in sequence.

---
*PR created automatically by Jules for task [14116549918726564984](https://jules.google.com/task/14116549918726564984) started by @hana89088*