### PR TITLE
⚡ Bolt: [performance improvement] Reduce O(N) loop delay in process_voice_command broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-02 - O(N) Latency Spike in Broadcast Processing
+**Learning:** Sequential processing of external API calls in a broadcast loop causes an O(N) latency bottleneck.
+**Action:** Use asyncio.gather for concurrent processing to achieve O(1) latency relative to connection count.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -165,9 +165,12 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            # Process all clients concurrently to achieve O(1) latency relative to connection count
+            await asyncio.gather(*(process_for_client(client) for client in list(self.clients)))
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
💡 What: Replaced sequential `for` loop in `process_voice_command` with an asynchronous `asyncio.gather` approach for broadcasting messages.
🎯 Why: Iterating sequentially and waiting for potentially slow, remote API responses from ElevenLabs or OpenAI for every client in the active list created an O(N) latency problem where each additional connected client increased the delay dramatically for subsequent clients.
📊 Impact: Total message broadcast latency is reduced from O(N) back to roughly O(1) in connection counts, ensuring the system can properly serve multiple frontends simultaneously without stalling. 
🔬 Measurement: Verified the code syntax using `py_compile`. Can be tested in real-time by adding two artificial clients to the `websockets` broadcast method while observing processing latency timestamps between them.

---
*PR created automatically by Jules for task [16965774940161277667](https://jules.google.com/task/16965774940161277667) started by @hana89088*