### PR TITLE
⚡ Bolt: Optimize WebSocket Broadcast & JSON Serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Avoid O(N) WebSockets API and Serialization Bottlenecks
+**Learning:** Sequential processing in broadcast methods, especially those involving external API calls (like OpenAI/ElevenLabs) or JSON serialization within comprehensions for multiple WebSocket clients, leads to O(N) latency relative to connection counts, severely degrading responsiveness.
+**Action:** Always use `asyncio.gather` for concurrent processing across multiple clients and extract JSON serialization out of broadcast loops to compute it exactly once.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,9 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients]
             )
             
     def start_voice_recognition(self):
@@ -165,9 +166,11 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            await asyncio.gather(*(process_for_client(client) for client in self.clients))
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
### 💡 What
- Extracted `json.dumps(message)` in the `broadcast` method to serialize the message only once instead of for every connected client.
- Replaced the sequential iteration over connected clients in `process_voice_command` with concurrent processing using `asyncio.gather`.

### 🎯 Why
- Serializing the message for every client within a list comprehension inside `broadcast` scales linearly (O(N)) with the number of clients, degrading responsiveness.
- Sequentially processing external network calls (e.g., getting OpenAI responses and ElevenLabs TTS) for every client in a loop inside `process_voice_command` caused severe O(N) latency bottlenecks, where subsequent clients had to wait for previous clients' responses to finish.

### 📊 Impact
- Reduces serialization overhead from O(N) to O(1) in message broadcasts.
- Reduces AI response generation latency for broadcast voice commands from O(N) to O(1) relative to connection count, improving responsiveness significantly in multi-client scenarios.

### 🔬 Measurement
This optimization can be verified by observing responsiveness in a multi-client setup. Specifically, trigger a broadcast voice command (when multiple clients are connected to the WebSocket server without a specified origin client) and measure the time it takes for all clients to receive the initial `status` message and the subsequent `response`/`audio` messages compared to before. They should arrive almost simultaneously now.

---
*PR created automatically by Jules for task [4649482522431818511](https://jules.google.com/task/4649482522431818511) started by @hana89088*