### PR TITLE
⚡ Bolt: Initialize microphone stream outside the continuous loop to reduce audio latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Avoid Continuous PyAudio Stream Initialization in Loops
+**Learning:** In PyAudio, repeatedly opening and closing microphone streams within a `while` loop (like `with self.microphone as source:`) introduces significant audio latency, and causes dropped audio frames. It operates as an anti-pattern when processing continuous streams.
+**Action:** When implementing continuous audio recognition loops (like in `src/python/main.py`), ensure the PyAudio microphone stream initialization occurs once, outside the continuous processing `while` loop, wrapping it to maintain state rather than re-creating it.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -115,37 +115,39 @@ class AIAssistant:
         
     def voice_recognition_loop(self):
         """Continuous voice recognition loop"""
+        # Bolt Performance Note: Initialize microphone stream outside the while loop.
+        # Repeatedly opening and closing the PyAudio stream inside the loop causes
+        # significant audio latency and can lead to dropped audio frames.
         with self.microphone as source:
             self.recognizer.adjust_for_ambient_noise(source)
             
-        while self.is_listening:
-            try:
-                with self.microphone as source:
+            while self.is_listening:
+                try:
                     # Listen for audio with timeout
                     audio = self.recognizer.listen(source, timeout=1, phrase_time_limit=5)
                     
-                try:
-                    # Recognize speech using Google Speech Recognition
-                    text = self.recognizer.recognize_google(audio)
-                    logger.info(f"Recognized: {text}")
-                    
-                    # Check for activation keyword
-                    if VOICE_ACTIVATION_KEYWORD in text.lower():
-                        # Remove activation keyword and process
-                        command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
-                        if command:
-                            asyncio.run_coroutine_threadsafe(
-                                self.process_voice_command(command),
-                                asyncio.get_event_loop()
-                            )
-                            
-                except sr.UnknownValueError:
-                    pass  # Could not understand audio
-                except sr.RequestError as e:
-                    logger.error(f"Speech recognition error: {e}")
-                    
-            except sr.WaitTimeoutError:
-                pass  # Timeout, continue listening
+                    try:
+                        # Recognize speech using Google Speech Recognition
+                        text = self.recognizer.recognize_google(audio)
+                        logger.info(f"Recognized: {text}")
+
+                        # Check for activation keyword
+                        if VOICE_ACTIVATION_KEYWORD in text.lower():
+                            # Remove activation keyword and process
+                            command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
+                            if command:
+                                asyncio.run_coroutine_threadsafe(
+                                    self.process_voice_command(command),
+                                    asyncio.get_event_loop()
+                                )
+
+                    except sr.UnknownValueError:
+                        pass  # Could not understand audio
+                    except sr.RequestError as e:
+                        logger.error(f"Speech recognition error: {e}")
+
+                except sr.WaitTimeoutError:
+                    pass  # Timeout, continue listening
                 
     async def process_voice_command(self, command, websocket=None):
         """Process voice command for a specific client or broadcast if none specified"""


### PR DESCRIPTION
**💡 What:** Moved the `while self.is_listening:` loop inside the `with self.microphone as source:` block in the `voice_recognition_loop` method in `src/python/main.py`.

**🎯 Why:** Inside a continuous voice recognition loop, opening and closing the PyAudio stream inside the `while` loop re-initializes the stream during every iteration. This adds severe audio latency and drops audio frames between each iteration, which is a performance bottleneck for continuous streams. 

**📊 Impact:** Drastically reduces audio processing latency and ensures smooth continuous audio capture without missing frames between yields. 

**🔬 Measurement:** The fix can be verified by observing smoother, near real-time text-to-speech feedback from the terminal logs when speaking continuously, with no delay from PyAudio re-initialization.

A performance journal was also added at `.jules/bolt.md` reflecting this specific architectural learning.

---
*PR created automatically by Jules for task [8425824397414143378](https://jules.google.com/task/8425824397414143378) started by @hana89088*