### PR TITLE
⚡ Bolt: [performance improvement] Concurrent client processing over broadcast

### DIFF
--- a/src/python/main.py
+++ b/src/python/main.py
@@ -165,9 +165,12 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            # ⚡ Bolt: Use asyncio.gather to process all clients concurrently, eliminating O(N) sequential blocking latency
+            await asyncio.gather(*(process_for_client(client) for client in self.clients))
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
💡 **What**: Replaced the sequential `for client in list(self.clients):` broadcast loop in `process_voice_command` with a concurrent solution utilizing `asyncio.gather`. 
🎯 **Why**: The original implementation sequentially awaited the `get_ai_response` call (which involves network requests to LLM APIs) for each client. For `N` active clients, this meant an `O(N)` scaling delay, causing subsequent clients to block and wait for preceding clients' network requests to resolve before even initiating theirs.
📊 **Impact**: Reduces broadcasting latency relative to connection count from `O(N)` back to `O(1)`. All clients now trigger their inferences simultaneously and receive responses independently. 
🔬 **Measurement**: Connect multiple clients (e.g., Unity/Electron frontends), trigger a `voice_command` broadcast, and measure the arrival delta between responses. The time taken to receive responses should now be near-identical across clients, whereas previously it would incrementally compound per client.

---
*PR created automatically by Jules for task [5425997323961115639](https://jules.google.com/task/5425997323961115639) started by @hana89088*