### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-06 - WebSocket Broadcast Serialization Bottleneck
+**Learning:** Found O(N) performance bottleneck in WebSocket broadcasts where `json.dumps()` was being called inside a list comprehension for `asyncio.gather`. In Python's `asyncio`, this blocks the event loop N times for the exact same serialization work.
+**Action:** Always pre-serialize payloads before iterating over multiple WebSocket clients to ensure O(1) serialization overhead and maintain predictable event loop execution times.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,10 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Pre-serialize payload to avoid O(N) serialization bottleneck
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients]
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
### 💡 What
Extracted `json.dumps(message)` outside of the list comprehension within the `broadcast` method in `src/python/main.py`.

### 🎯 Why
In Python's `asyncio`, blocking the event loop with synchronous operations like JSON serialization can degrade performance. Executing `json.dumps()` inside a list comprehension for a WebSocket broadcast means the exact same payload is serialized N times (where N is the number of connected clients), creating an O(N) serialization bottleneck.

### 📊 Impact
Changes the serialization overhead for broadcasting messages from O(N) to O(1). This reduces event loop blocking and CPU cycles, allowing the application to scale better with multiple connected clients.

### 🔬 Measurement
To verify the improvement, measure the execution time of the `broadcast` function or profile the event loop latency with multiple clients connected while broadcasting. The overhead should remain relatively flat regardless of client count.

---
*PR created automatically by Jules for task [16289725109258604603](https://jules.google.com/task/16289725109258604603) started by @hana89088*