### PR TITLE
⚡ Bolt: O(N) to O(1) optimization for WebSocket Broadcast processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - WebSocket Broadcast O(N) Bottlenecks
+
+**Learning:** When broadcasting messages to multiple WebSocket clients or processing commands for all active clients sequentially (e.g., using a `for` loop), the application experiences an O(N) performance bottleneck. Redundant JSON serialization inside the broadcast loop and sequential awaiting of external API calls per client significantly degrade performance as the number of clients increases.
+
+**Action:** Always pre-serialize JSON messages outside the broadcast loop. Utilize `asyncio.gather` with `return_exceptions=True` to concurrently process and broadcast to all active clients, effectively changing the latency from O(N) to O(1) relative to connection count.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Pre-serialize JSON once to avoid O(N) serialization cost
+            message_json = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(message_json) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):
@@ -163,11 +166,17 @@ class AIAssistant:
             await self.send_response(response, websocket)
         else:
             await self.broadcast(status_msg)
-            # If no specific client, we'll process it for all active clients
-            # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+
+            # Concurrently process for all clients to avoid O(N) sequential bottleneck
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            if self.clients:
+                await asyncio.gather(
+                    *[process_for_client(client) for client in self.clients],
+                    return_exceptions=True
+                )
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
💡 **What:** 
Replaced sequential `for` loops with `asyncio.gather` for broadcasting and processing client commands in `src/python/main.py`. Pre-serialized JSON payload strictly once before dispatching to all active clients.

🎯 **Why:** 
Previously, the backend was iterating over the `clients` set linearly inside `process_voice_command` when broadcasting AI responses. This resulted in awaiting external `openai` API calls sequentially for every active client. Furthermore, the base `broadcast` method re-serialized the exact same dictionary payload into JSON string $N$ times, adding unnecessary CPU cycles proportional to connected clients.

📊 **Impact:** 
Changes broadcast processing latency from strictly $O(N)$ to practically $O(1)$ relative to connection count, vastly improving scalability for concurrent multi-client connections. Saves CPU cycles by removing redundant dictionary serialization operations. Prevents the crash of an entire broadcast loop if a single client stream encounters an error by utilizing `return_exceptions=True`.

🔬 **Measurement:** 
Connect multiple test WebSocket clients simultaneously and invoke a global voice command event. Observe that the total latency for responses is now equivalent to a single OpenAI API call rather than $N \times \text{OpenAI call time}$. Verified syntactical correctness via `py_compile`.

---
*PR created automatically by Jules for task [10318789792202666322](https://jules.google.com/task/10318789792202666322) started by @hana89088*