### PR TITLE
⚡ Bolt: [performance improvement] optimize websocket broadcast latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - Avoid sequential processing in WebSocket Broadcasts
+**Learning:** During broadcast operations to multiple WebSocket clients, looping sequentially to perform expensive operations (like JSON serialization or API calls) causes an O(N) latency bottleneck.
+**Action:** Extract computation exactly once outside the loop (like `json.dumps(message)`), and use `asyncio.gather` to concurrently process external API calls or send responses for all clients simultaneously.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # OPTIMIZATION: Serialize JSON once for all clients instead of O(N) times
+            # Expected impact: Reduces CPU overhead during broadcasts, especially with many clients
+            json_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(json_message) for client in self.clients]
             )
             
     def start_voice_recognition(self):
@@ -165,9 +168,17 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+
+            # OPTIMIZATION: Process API requests and send responses concurrently instead of sequentially
+            # Expected impact: Converts O(N) latency bottleneck into O(1) processing time with respect to number of connected clients
+            async def process_for_client(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            if self.clients:
+                await asyncio.gather(
+                    *[process_for_client(client) for client in list(self.clients)]
+                )
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
**💡 What**
1. In `src/python/main.py` -> `broadcast`, we now serialize the `message` to JSON exactly once outside the loop instead of $O(N)$ times.
2. In `src/python/main.py` -> `process_voice_command`, we wrapped the sequential sequential API processing logic (`get_ai_response` -> `send_response`) into an `async def process_for_client` closure and mapped it across clients using `asyncio.gather`. 

**🎯 Why**
Previously, when the AI processed a global command to all connected clients, it iteratively blocked on each API call (waiting for OpenAI to reply) before moving onto the next client. This caused significant sequential latency ($O(N)$ bottleneck). The JSON serialization loop issue was similarly unnecessary CPU overhead for larger pools of clients.

**📊 Impact**
- Reduces latency bottleneck for multi-client processing from $O(N)$ to $O(1)$ relative to connection count.
- Reduces JSON serialization overhead from $O(N)$ CPU cycles to exactly 1 execution per broadcast.

**🔬 Measurement**
Connect multiple clients. Trigger a voice command. The processing will now dispatch API requests for all connections concurrently.

Also recorded a journal entry to `.jules/bolt.md` reflecting on how sequential processing during broadcast loops causes significant scale bottlenecks.

---
*PR created automatically by Jules for task [10571202085075586892](https://jules.google.com/task/10571202085075586892) started by @hana89088*