### PR TITLE
⚡ Bolt: Prevent repeated stream init latency in PyAudio

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Avoid repeated stream initialization latency in PyAudio]
+**Learning:** Initializing the PyAudio microphone stream using `with self.microphone as source:` inside a continuous processing loop (`while self.is_listening:`) introduces significant latency because the stream is repeatedly opened and closed.
+**Action:** Move the continuous `while` loop inside the `with` block so the stream is initialized only once outside the loop.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -69,7 +69,7 @@ class AIAssistant:
                 await self.process_client_message(data, websocket)
                 
         except websockets.exceptions.ConnectionClosed:
-            pass
+            logger.debug("WebSocket connection closed")
         finally:
             self.clients.remove(websocket)
             if websocket in self.client_states:
@@ -118,34 +118,33 @@ class AIAssistant:
         with self.microphone as source:
             self.recognizer.adjust_for_ambient_noise(source)
             
-        while self.is_listening:
-            try:
-                with self.microphone as source:
+            while self.is_listening:
+                try:
                     # Listen for audio with timeout
                     audio = self.recognizer.listen(source, timeout=1, phrase_time_limit=5)
                     
-                try:
-                    # Recognize speech using Google Speech Recognition
-                    text = self.recognizer.recognize_google(audio)
-                    logger.info(f"Recognized: {text}")
-                    
-                    # Check for activation keyword
-                    if VOICE_ACTIVATION_KEYWORD in text.lower():
-                        # Remove activation keyword and process
-                        command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
-                        if command:
-                            asyncio.run_coroutine_threadsafe(
-                                self.process_voice_command(command),
-                                asyncio.get_event_loop()
-                            )
-                            
-                except sr.UnknownValueError:
-                    pass  # Could not understand audio
-                except sr.RequestError as e:
-                    logger.error(f"Speech recognition error: {e}")
-                    
-            except sr.WaitTimeoutError:
-                pass  # Timeout, continue listening
+                    try:
+                        # Recognize speech using Google Speech Recognition
+                        text = self.recognizer.recognize_google(audio)
+                        logger.info(f"Recognized: {text}")
+
+                        # Check for activation keyword
+                        if VOICE_ACTIVATION_KEYWORD in text.lower():
+                            # Remove activation keyword and process
+                            command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
+                            if command:
+                                asyncio.run_coroutine_threadsafe(
+                                    self.process_voice_command(command),
+                                    asyncio.get_event_loop()
+                                )
+
+                    except sr.UnknownValueError:
+                        logger.debug("Could not understand audio")
+                    except sr.RequestError as e:
+                        logger.error(f"Speech recognition error: {e}")
+
+                except sr.WaitTimeoutError:
+                    logger.debug("Wait timeout, continue listening")
                 
     async def process_voice_command(self, command, websocket=None):
         """Process voice command for a specific client or broadcast if none specified"""


### PR DESCRIPTION
💡 **What**: Moved the continuous `while self.is_listening:` loop inside the `with self.microphone as source:` block in the `voice_recognition_loop` of `src/python/main.py`.

🎯 **Why**: The original implementation was repeatedly opening and closing the PyAudio microphone stream on every iteration of the while loop. This is an expensive operation that introduced significant latency, caused potential audio dropouts, and reduced the overall responsiveness of the continuous voice recognition feature.

📊 **Impact**: Eliminates the overhead of repeatedly initializing the microphone stream. The stream is now opened exactly once when listening starts, and closed when it stops. This significantly improves real-time voice processing latency and reduces CPU/audio device thrashing.

🔬 **Measurement**: 
- Monitor CPU usage during voice recognition before and after the change.
- Measure the time from speaking the activation keyword to the system processing the command; this latency should be noticeably reduced.
- Verify that continuous listening no longer produces choppy or dropped audio frames.

---
*PR created automatically by Jules for task [10549808193194463351](https://jules.google.com/task/10549808193194463351) started by @hana89088*