### PR TITLE
⚡ Bolt: Optimize WebSocket broadcasts and API calls to O(1) latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-15 - WebSocket Broadcast Bottlenecks
+**Learning:** In the Python backend, broadcasting messages or processing external API calls (like OpenAI) sequentially across connected WebSocket clients creates an O(N) latency bottleneck where N is the number of connections. Additionally, computing `json.dumps()` inside broadcast comprehensions causes redundant serialization overhead.
+**Action:** Always use `asyncio.gather` for concurrent API calls and message sending across clients to maintain O(1) latency. Extract `json.dumps()` out of broadcast loops to serialize exactly once.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,10 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Serialize JSON once outside the loop to avoid redundant computation
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients]
             )
             
     def start_voice_recognition(self):
@@ -165,9 +167,15 @@ class AIAssistant:
             await self.broadcast(status_msg)
             # If no specific client, we'll process it for all active clients
             # This is a bit tricky for a shared mic, but works for broadcast
-            for client in list(self.clients):
+            # ⚡ Bolt: Process AI responses concurrently for all clients to maintain O(1) latency
+            async def process_and_send(client):
                 response = await self.get_ai_response(command, client)
                 await self.send_response(response, client)
+
+            if self.clients:
+                await asyncio.gather(
+                    *[process_and_send(client) for client in list(self.clients)]
+                )
         
     async def get_ai_response(self, user_input: str, websocket) -> Dict[str, Any]:
         """Get response from OpenAI"""


### PR DESCRIPTION
💡 What: Extract `json.dumps` serialization out of WebSocket broadcast loops and use `asyncio.gather` to concurrently process external API calls (e.g. OpenAI interactions) when broadcasting commands to all clients.

🎯 Why: Previously, broadcasting messages serialized the JSON multiple times (O(N) operation inside the list comprehension). Worse, for un-targeted voice commands, the `for client in list(self.clients):` loop sequentially awaited the `get_ai_response` for each client. For N connected clients, the Nth client had to wait for N-1 external OpenAI calls to finish before receiving their response, leading to massive latency spikes as client count increases.

📊 Impact: 
- Reduces JSON serialization overhead during broadcasts from O(N) to O(1)
- Eliminates sequential I/O blocking for global voice commands, reducing total processing latency for N clients from O(N) to O(1).
- Improves overall responsiveness and scale under multi-client loads.

🔬 Measurement: Verify correctness by starting multiple frontend clients (Electron/Unity) and issuing a voice command without targeting a specific client. All clients should now receive the response almost concurrently, rather than staggered. Code correctness verified via `python -m py_compile` and automated testing.

---
*PR created automatically by Jules for task [5068548344146928131](https://jules.google.com/task/5068548344146928131) started by @hana89088*