### PR TITLE
⚡ Bolt: Optimize JSON serialization in WebSocket broadcasts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - JSON Serialization in WebSocket Broadcasts
+**Learning:** The Python backend's `broadcast` function was serializing the same dictionary to JSON O(N) times (once per connected client) inside an `asyncio.gather` list comprehension. This creates an unnecessary CPU bottleneck.
+**Action:** Always extract `json.dumps()` calls outside of broadcast loops to compute the string exactly once, reducing serialization overhead to O(1).

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Cache JSON serialization to avoid O(N) redundant processing during broadcasts
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
**What**: Extracted JSON serialization outside the client loop in the `broadcast` method. Added `return_exceptions=True` to the `asyncio.gather` call to follow broadcast best practices.
**Why**: To prevent serializing the identical message O(N) times (once for each connected client).
**Impact**: Reduces CPU serialization overhead from O(N) to O(1) during client broadcasts. Prevents individual client disconnect exceptions from cancelling the entire broadcast.
**Measurement**: Can be verified by load testing with multiple WebSocket clients and observing reduced CPU utilization during broadcasts.

---
*PR created automatically by Jules for task [16980887905626184332](https://jules.google.com/task/16980887905626184332) started by @hana89088*