### PR TITLE
⚡ Bolt: Extract JSON serialization from WebSocket broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Extracting Serialization from Broadcast Loops
+**Learning:** In WebSocket broadcast functions (e.g., `broadcast` in `src/python/main.py`), performing JSON serialization inside a list comprehension for `asyncio.gather` causes O(N) serialization overhead relative to connection count.
+**Action:** Always compute identical serialized payloads outside the loop exactly once for O(1) serialization performance.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,10 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # OPTIMIZATION: Serialize JSON exactly once outside the loop to avoid O(N) serialization overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients]
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps(message)` out of the list comprehension in the `broadcast` method.
🎯 Why: Performing JSON serialization inside the list comprehension caused O(N) serialization overhead relative to the number of connected clients.
📊 Impact: Reduces serialization overhead from O(N) to O(1), improving CPU efficiency and scalability when broadcasting to multiple clients.
🔬 Measurement: Monitor CPU utilization during high-volume broadcasts with multiple connected clients; check average latency of message delivery.

---
*PR created automatically by Jules for task [14056297848122640102](https://jules.google.com/task/14056297848122640102) started by @hana89088*