### PR TITLE
⚡ Bolt: Extract JSON serialization out of broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-25 - Extracted JSON serialization from broadcast loop
+**Learning:** Serializing JSON inside a broadcast list comprehension causes redundant O(N) CPU overhead, scaling poorly with connection count.
+**Action:** Always serialize broadcast messages exactly once before fanning out to clients.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Optimize performance by serializing JSON exactly once before broadcasting
+            # instead of inside the list comprehension. Reduces serialization overhead from O(N) to O(1).
+            serialized_msg = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_msg) for client in self.clients]
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
What: Extracted `json.dumps(message)` outside of the `[client.send(...) for client in self.clients]` loop in `broadcast()`.
Why: Avoids redundant O(N) JSON serialization overhead when broadcasting to multiple clients.
Impact: Achieves O(1) JSON serialization cost relative to connection count, reducing CPU load.
Measurement: Observe CPU load reduction during high-volume broadcasts with many connected clients.

---
*PR created automatically by Jules for task [1974235363028926573](https://jules.google.com/task/1974235363028926573) started by @hana89088*