### PR TITLE
⚡ Bolt: Extract JSON serialization from WebSocket broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Extracting JSON serialization from broadcast loops
+**Learning:** In WebSocket broadcast loops using `asyncio.gather`, inline operations like `json.dumps(message)` are executed per-client before the coroutines are gathered. This transforms an otherwise O(1) network broadcasting step into an O(N) CPU bottleneck when handling many concurrent connections.
+**Action:** Always extract static serializations (like JSON encoding) outside of broadcast comprehensions or loops so the CPU cost is incurred exactly once.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,10 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Optimize: compute JSON serialization once instead of per-client
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients]
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps(message)` outside of the `asyncio.gather` comprehension in the `broadcast` method.
🎯 Why: Previously, the message was serialized to JSON individually for every connected client. For N clients, this resulted in N identical JSON serializations, causing an O(N) CPU bottleneck.
📊 Impact: Reduces CPU overhead during broadcasts from O(N) to O(1) with respect to JSON serialization, significantly improving performance with many connected clients.
🔬 Measurement: Verify by profiling CPU usage during a broadcast to many concurrent WebSocket connections; serialization time will remain constant instead of scaling linearly with client count.

---
*PR created automatically by Jules for task [12722366196721155706](https://jules.google.com/task/12722366196721155706) started by @hana89088*