### PR TITLE
⚡ Bolt: Keep PyAudio stream open in listening loop to reduce latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Avoid PyAudio Stream Reinitialization Latency]
+**Learning:** Initializing PyAudio microphone streams repeatedly inside a `while` loop (`with self.microphone as source:`) introduces significant latency because opening and closing the audio device stream is a slow operation.
+**Action:** Always wrap the continuous listening loop (`while`) inside a single `with self.microphone as source:` block to keep the stream open continuously.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -118,34 +118,33 @@ class AIAssistant:
         with self.microphone as source:
             self.recognizer.adjust_for_ambient_noise(source)
             
-        while self.is_listening:
-            try:
-                with self.microphone as source:
+            while self.is_listening:
+                try:
                     # Listen for audio with timeout
                     audio = self.recognizer.listen(source, timeout=1, phrase_time_limit=5)
                     
-                try:
-                    # Recognize speech using Google Speech Recognition
-                    text = self.recognizer.recognize_google(audio)
-                    logger.info(f"Recognized: {text}")
-                    
-                    # Check for activation keyword
-                    if VOICE_ACTIVATION_KEYWORD in text.lower():
-                        # Remove activation keyword and process
-                        command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
-                        if command:
-                            asyncio.run_coroutine_threadsafe(
-                                self.process_voice_command(command),
-                                asyncio.get_event_loop()
-                            )
-                            
-                except sr.UnknownValueError:
-                    pass  # Could not understand audio
-                except sr.RequestError as e:
-                    logger.error(f"Speech recognition error: {e}")
-                    
-            except sr.WaitTimeoutError:
-                pass  # Timeout, continue listening
+                    try:
+                        # Recognize speech using Google Speech Recognition
+                        text = self.recognizer.recognize_google(audio)
+                        logger.info(f"Recognized: {text}")
+
+                        # Check for activation keyword
+                        if VOICE_ACTIVATION_KEYWORD in text.lower():
+                            # Remove activation keyword and process
+                            command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
+                            if command:
+                                asyncio.run_coroutine_threadsafe(
+                                    self.process_voice_command(command),
+                                    asyncio.get_event_loop()
+                                )
+
+                    except sr.UnknownValueError:
+                        logger.debug("Could not understand audio")
+                    except sr.RequestError as e:
+                        logger.error(f"Speech recognition error: {e}")
+
+                except sr.WaitTimeoutError:
+                    logger.debug("Timeout, continue listening")
                 
     async def process_voice_command(self, command, websocket=None):
         """Process voice command for a specific client or broadcast if none specified"""


### PR DESCRIPTION
🎯 What: Moved the `while self.is_listening` loop inside the `with self.microphone as source:` block in `voice_recognition_loop` and replaced silent `pass` handlers with `logger.debug`.
💡 Why: Re-initializing the PyAudio stream inside the loop on every iteration causes significant latency.
📊 Impact: Eliminates the stream initialization overhead on every loop iteration, improving responsiveness.
🔬 Measurement: Run the backend and observe the reduced latency between consecutive voice commands.

---
*PR created automatically by Jules for task [6364968972016261504](https://jules.google.com/task/6364968972016261504) started by @hana89088*