### PR TITLE
⚡ Bolt: Prevent microphone stream re-initialization latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Audio Stream Re-initialization Latency
+**Learning:** Initializing PyAudio microphone streams (`with self.microphone as source:`) inside a continuous `while` loop introduces significant latency because the stream is repeatedly opened and closed.
+**Action:** Always initialize long-running audio streams outside the `while` loop and only perform the listen operations inside the loop.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -118,34 +118,34 @@ class AIAssistant:
         with self.microphone as source:
             self.recognizer.adjust_for_ambient_noise(source)
             
-        while self.is_listening:
-            try:
-                with self.microphone as source:
+        with self.microphone as source:
+            while self.is_listening:
+                try:
                     # Listen for audio with timeout
                     audio = self.recognizer.listen(source, timeout=1, phrase_time_limit=5)
                     
-                try:
-                    # Recognize speech using Google Speech Recognition
-                    text = self.recognizer.recognize_google(audio)
-                    logger.info(f"Recognized: {text}")
-                    
-                    # Check for activation keyword
-                    if VOICE_ACTIVATION_KEYWORD in text.lower():
-                        # Remove activation keyword and process
-                        command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
-                        if command:
-                            asyncio.run_coroutine_threadsafe(
-                                self.process_voice_command(command),
-                                asyncio.get_event_loop()
-                            )
-                            
-                except sr.UnknownValueError:
-                    pass  # Could not understand audio
-                except sr.RequestError as e:
-                    logger.error(f"Speech recognition error: {e}")
-                    
-            except sr.WaitTimeoutError:
-                pass  # Timeout, continue listening
+                    try:
+                        # Recognize speech using Google Speech Recognition
+                        text = self.recognizer.recognize_google(audio)
+                        logger.info(f"Recognized: {text}")
+
+                        # Check for activation keyword
+                        if VOICE_ACTIVATION_KEYWORD in text.lower():
+                            # Remove activation keyword and process
+                            command = text.lower().replace(VOICE_ACTIVATION_KEYWORD, '').strip()
+                            if command:
+                                asyncio.run_coroutine_threadsafe(
+                                    self.process_voice_command(command),
+                                    asyncio.get_event_loop()
+                                )
+
+                    except sr.UnknownValueError:
+                        pass  # Could not understand audio
+                    except sr.RequestError as e:
+                        logger.error(f"Speech recognition error: {e}")
+
+                except sr.WaitTimeoutError:
+                    pass  # Timeout, continue listening
                 
     async def process_voice_command(self, command, websocket=None):
         """Process voice command for a specific client or broadcast if none specified"""


### PR DESCRIPTION
**What**: Move microphone initialization (`with self.microphone as source:`) outside the `while self.is_listening` loop in `src/python/main.py`.

**Why**: Re-opening the underlying PyAudio stream on every iteration of the continuous listening loop causes severe CPU overhead and latency between speech inputs.

**Impact**: Eliminates significant delay per recognition loop iteration, providing a much faster, smoother continuous listening experience.

**Measurement**: Observe the delay between phrases when talking continuously to the assistant; it should be noticeably reduced.

---
*PR created automatically by Jules for task [4103101481659018629](https://jules.google.com/task/4103101481659018629) started by @hana89088*