### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast serialization and fault tolerance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-06 - WebSocket Broadcast Fast-Fail Vulnerability and Serialization Overhead
+**Learning:** By default, `asyncio.gather` fast-fails when any of its awaitables raises an exception. In a WebSocket broadcast scenario, if one client disconnects concurrently and its `send` task raises an exception, the entire broadcast task fails immediately, preventing other connected clients from receiving the message. Additionally, `json.dumps` inside a list comprehension creates O(N) serialization overhead.
+**Action:** When broadcasting to multiple clients using `asyncio.gather`, always use `return_exceptions=True` to ensure fault tolerance. Additionally, extract redundant operations like `json.dumps(message)` outside the loop to optimize for O(1) processing instead of O(N).

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,12 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # OPTIMIZATION: Serialize JSON exactly once to avoid O(N) serialization overhead
+            serialized_message = json.dumps(message)
+            # Use return_exceptions=True to prevent one client's disconnection from failing the entire broadcast
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
### 💡 What
- Extracted `json.dumps(message)` outside the loop in `broadcast()`.
- Added `return_exceptions=True` to the `asyncio.gather()` call.

### 🎯 Why
- **Performance**: Inside a list comprehension, `json.dumps` executes for every connected client, generating an O(N) serialization cost. By extracting it, we pay the serialization cost exactly once (O(1)).
- **Fault Tolerance**: By default, `asyncio.gather` fast-fails if any of its coroutines throw an exception. If a client disconnected concurrently, their `send` task could fail, propagating the exception up and cancelling the broadcast for all *other* connected clients.

### 📊 Impact
- Reduces CPU time spent serializing JSON messages during broadcasts from O(N) to O(1) relative to connection count.
- Fixes a critical fault tolerance edge case where a single client's WebSocket error could disrupt messages for all other clients.

### 🔬 Measurement
- Visual inspection of CPU usage during high-connection broadcast loads will show reduced spikes.
- Simulating a broken pipe / disconnection of one client during a broadcast will no longer prevent the remaining clients from receiving the broadcast message.

---
*PR created automatically by Jules for task [11989730383529709021](https://jules.google.com/task/11989730383529709021) started by @hana89088*