### PR TITLE
⚡ Bolt: Optimize JSON serialization in WebSocket broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Extract JSON serialization out of broadcast loops
+**Learning:** In WebSocket broadcast loops, serializing the message payload (e.g., `json.dumps()`) inside the comprehension/loop results in O(N) redundant string computations.
+**Action:** Always extract JSON serialization or any constant computation outside the broadcast loop so it's computed exactly once. Also, using `return_exceptions=True` with `asyncio.gather` prevents a single disconnected client from failing the entire broadcast.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Serialize message once instead of for every client
+            json_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(json_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
### 💡 What
Extracted `json.dumps(message)` outside the list comprehension in the `broadcast` method so it's computed exactly once per broadcast instead of once per connected client. Added `return_exceptions=True` to `asyncio.gather` to prevent one failing connection from dropping the broadcast for everyone.

### 🎯 Why
Serializing the exact same dictionary to a JSON string for every active client is an O(N) performance bottleneck that blocks the event loop unnecessarily. 

### 📊 Impact
Reduces JSON serialization overhead from O(N) to O(1) in the broadcast path. This significantly decreases the time spent in the synchronous `json.dumps` function when broadcasting to multiple clients, reducing event loop latency.

### 🔬 Measurement
The improvement can be verified by running a profiler during a broadcast to many (e.g., 50+) connected clients. The time spent in `json.dumps` will be proportional to 1 rather than the number of active WebSockets.

---
*PR created automatically by Jules for task [5061338555167423285](https://jules.google.com/task/5061338555167423285) started by @hana89088*