### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - WebSocket Broadcast Optimization
+**Learning:** In `src/python/main.py`, the `AIAssistant.broadcast` method previously serialized the JSON message inside the loop, causing redundant O(N) serialization. Additionally, missing `return_exceptions=True` on `asyncio.gather` meant one disconnected client could fail the whole broadcast.
+**Action:** When broadcasting data to multiple clients, serialize payloads outside the loop exactly once (O(1)) and use `return_exceptions=True` to ensure fault-tolerance.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Serialize JSON once to avoid O(N) redundant serialization
+            json_msg = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(json_msg) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps(message)` out of the `broadcast` loop in `src/python/main.py` and added `return_exceptions=True` to `asyncio.gather`.
🎯 Why: Previously, the backend serialized the identical JSON message O(N) times for N connected WebSocket clients, causing unnecessary CPU overhead during broadcasts. Adding `return_exceptions=True` also prevents one disconnected client from failing the entire gather awaitable.
📊 Impact: Reduces broadcast serialization cost from O(N) to O(1), saving CPU cycles and minimizing event loop lag during multi-client broadcasts.
🔬 Measurement: Run a profiler with multiple concurrent WebSocket clients; CPU time spent in `json.dumps` during broadcasts will be reduced by a factor of N.

---
*PR created automatically by Jules for task [9573542063907803292](https://jules.google.com/task/9573542063907803292) started by @hana89088*