### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Redundant JSON Serialization in Broadcast Loop
+**Learning:** In the Python backend, iterating over active WebSocket clients and calling `json.dumps(message)` for each client within an `asyncio.gather` list comprehension creates an O(N) serialization overhead. JSON serialization is synchronous and blocks the event loop; doing it N times instead of once significantly degrades broadcast performance under high concurrent connections.
+**Action:** Always extract `json.dumps()` operations outside of broadcast loops and pass the pre-serialized string to the client send methods. Use `return_exceptions=True` in `asyncio.gather` to prevent one client's error from aborting the entire broadcast.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,12 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Serialize JSON once (O(1)) instead of for every client (O(N))
+            # to prevent blocking the event loop on high concurrent connections
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extract `json.dumps()` out of the `asyncio.gather` list comprehension in the `broadcast` method, and add `return_exceptions=True`.
🎯 Why: Performing JSON serialization (a synchronous, blocking operation) inside a per-client loop creates an O(N) overhead. By extracting it, we compute it exactly once. `return_exceptions=True` ensures one disconnected client doesn't throw an error that aborts sending to the rest.
📊 Impact: Reduces O(N) serialization overhead to O(1) in the broadcast loop, maintaining constant latency relative to the number of connected clients.
🔬 Measurement: Can be measured by profiling the event loop lag during a broadcast to a large number of connected clients.

---
*PR created automatically by Jules for task [9874918150669245499](https://jules.google.com/task/9874918150669245499) started by @hana89088*