### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - JSON Serialization Overhead in Broadcasts
+**Learning:** Computing JSON serialization inside WebSocket broadcast loops creates redundant O(N) CPU overhead, and unhandled disconnection errors in `asyncio.gather` can fail the entire broadcast for all clients.
+**Action:** Always compute expensive serialization operations before broadcast loops and use `return_exceptions=True` in `asyncio.gather` to isolate client errors.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Optimize: compute JSON serialization once to avoid O(N) overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps(message)` out of the broadcast list comprehension and added `return_exceptions=True` to `asyncio.gather`.
🎯 Why: Computing JSON serialization inside the loop causes redundant O(N) overhead per message. Additionally, a single client exception could crash the broadcast for all clients.
📊 Impact: Reduces CPU serialization overhead from O(N) to O(1) where N is the number of connected clients. Improves broadcast reliability.
🔬 Measurement: Verify by connecting multiple clients and broadcasting a message, observing reduced CPU usage and ensuring one failing client doesn't block the message for others.

---
*PR created automatically by Jules for task [16073578277539192817](https://jules.google.com/task/16073578277539192817) started by @hana89088*