### PR TITLE
⚡ Bolt: Optimize JSON serialization overhead in WebSocket broadcasts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Redundant JSON Serialization in WebSocket Broadcasts
+**Learning:** In shared/broadcast WebSocket scenarios with multiple clients, inline serialization within a list comprehension (e.g., `[client.send(json.dumps(msg)) for client in clients]`) causes O(N) redundant string formatting, leading to unnecessary CPU load. Also `asyncio.gather` without `return_exceptions=True` can cause a single dropped connection to terminate the entire broadcast.
+**Action:** Always extract `json.dumps()` before broadcasting to active connections and use `return_exceptions=True` in `asyncio.gather`.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Serialize JSON once for O(1) performance instead of O(N)
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted json.dumps(message) outside the broadcast list comprehension in src/python/main.py, and added return_exceptions=True to asyncio.gather.
🎯 Why: Inline serialization within a list comprehension causes O(N) redundant string formatting. Doing it once reduces overhead. Also prevents a single connection error from failing the whole broadcast.
📊 Impact: Reduces broadcast serialization cost from O(N) to O(1), saving CPU cycles and preventing unhandled exceptions from terminating the task.
🔬 Measurement: Verify by connecting multiple clients; CPU load on broadcast should be slightly lower, and one disconnected client will not crash the broadcast for others.

---
*PR created automatically by Jules for task [14042338897900229570](https://jules.google.com/task/14042338897900229570) started by @hana89088*