### PR TITLE
⚡ Bolt: Optimize JSON serialization in WebSocket broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-26 - Broadcast JSON Serialization Overhead
+**Learning:** Broadcasting to multiple WebSockets with `asyncio.gather(*[client.send(json.dumps(msg)) for client in clients])` causes redundant O(N) JSON serialization overhead for identical payloads.
+**Action:** Always extract `json.dumps()` outside the broadcast loop/comprehension to serialize exactly once, then distribute the resulting string.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Serialize once to avoid O(N) redundant JSON encoding overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps(message)` outside the list comprehension in the `broadcast` function and added `return_exceptions=True` to `asyncio.gather`.
🎯 Why: Prevents O(N) redundant JSON serialization overhead when broadcasting the identical payload to multiple clients.
📊 Impact: Reduces CPU usage and latency for broadcasts from O(N) to O(1) regarding JSON encoding, and prevents a single failing client from crashing the entire broadcast batch.
🔬 Measurement: Run a profiler during a multi-client broadcast to verify `json.dumps` is called exactly once instead of N times per broadcast.

---
*PR created automatically by Jules for task [8212616139460281486](https://jules.google.com/task/8212616139460281486) started by @hana89088*