### PR TITLE
⚡ Bolt: Extract JSON serialization from WebSocket broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Extract JSON Serialization from Broadcast Loops
+**Learning:** In WebSocket broadcast scenarios, running `json.dumps()` inside the client iteration loop creates an O(N) serialization overhead where N is the number of connected clients. If there are many clients, this unnecessary redundant computation can cause event loop lag.
+**Action:** Always extract JSON serialization outside of the broadcast loop so the payload is serialized exactly once (O(1)). Also, use `return_exceptions=True` with `asyncio.gather` so one failing socket doesn't crash the entire broadcast operation.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,12 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt Optimization: Serialize JSON exactly once instead of O(N) times
+            # This reduces CPU overhead during broadcasts to multiple clients.
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps(message)` outside of the broadcast loop so it is computed exactly once instead of N times (where N is the number of connected clients). Also added `return_exceptions=True` to `asyncio.gather`.
🎯 Why: Running JSON serialization inside a comprehension for broadcasting creates redundant O(N) CPU overhead, which can block the asyncio event loop when many clients are connected. `return_exceptions=True` prevents a single disconnected client from aborting the entire broadcast.
📊 Impact: Reduces serialization overhead from O(N) to O(1), making broadcasts significantly faster and more stable under load.
🔬 Measurement: Verify by checking CPU usage during broadcasts to multiple clients, or reviewing the event loop lag metrics.

---
*PR created automatically by Jules for task [14201886229700987272](https://jules.google.com/task/14201886229700987272) started by @hana89088*