### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - O(N) Serialization Overhead in Broadcast
+**Learning:** Found a codebase-specific anti-pattern where JSON serialization was performed inside a list comprehension during WebSocket broadcasts, causing O(N) serialization overhead.
+**Action:** Always extract JSON serialization and other constant computations out of broadcast loops to compute exactly once, and use `return_exceptions=True` in `asyncio.gather` for robustness.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Serialize JSON exactly once to avoid redundant O(N) serialization overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps()` serialization out of the `asyncio.gather` broadcast loop and added `return_exceptions=True`.
🎯 Why: Previously, JSON serialization was performed O(N) times (once for each connected client). This eliminates redundant serialization overhead and prevents one client's connection error from crashing the entire broadcast.
📊 Impact: Reduces CPU usage and latency during broadcast events from O(N) serialization to O(1) serialization.
🔬 Measurement: Verify by checking that `json.dumps()` is only called once per broadcast message, and by monitoring CPU utilization during broadcasts to multiple clients.

---
*PR created automatically by Jules for task [17079665334419062492](https://jules.google.com/task/17079665334419062492) started by @hana89088*