### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast JSON serialization overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-31 - Optimize WebSocket broadcast JSON serialization overhead
+**Learning:** In the Python backend (`src/python/main.py`), broadcasting to WebSocket clients using `asyncio.gather` with a list comprehension calling `json.dumps` for every client causes O(N) serialization overhead, unnecessarily using CPU cycles and blocking the event loop.
+**Action:** Extract JSON serialization out of the broadcast loop so it's computed exactly once, changing serialization complexity to O(1). Additionally, use `return_exceptions=True` in `asyncio.gather` to prevent one client's disconnection error from propagating and failing the entire broadcast.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Serialize JSON exactly once to avoid O(N) overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
- **💡 What:** Extract JSON serialization out of the client broadcast loop and add `return_exceptions=True` to `asyncio.gather`.
- **🎯 Why:** Previously, `json.dumps` was called for every connected client, resulting in O(N) serialization overhead. Computing it once reduces CPU usage. Adding `return_exceptions=True` prevents a single client error from failing the broadcast.
- **📊 Impact:** Changes JSON serialization from O(N) to O(1) per broadcast, saving CPU cycles when many clients are connected.
- **🔬 Measurement:** Measure CPU usage during mass broadcasts, or observe event loop lag with multiple active connections.

---
*PR created automatically by Jules for task [12507793816090714653](https://jules.google.com/task/12507793816090714653) started by @hana89088*