### PR TITLE
⚡ Bolt: Optimize JSON serialization in WebSocket broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Extracting Serialization out of Broadcast Loops
+**Learning:** In WebSocket broadcast scenarios, calculating `json.dumps(message)` inside a list comprehension causes O(N) redundant serializations, which unnecessarily blocks the Python event loop.
+**Action:** Always pre-calculate JSON serialization outside the loop and pass the serialized string to each client connection to achieve O(1) serialization cost.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt Optimization: Serialize JSON exactly once to avoid O(N) redundant serialization overhead
+            serialized_msg = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_msg) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps` out of the client broadcast list comprehension and added `return_exceptions=True` to `asyncio.gather`.
🎯 Why: Calling `json.dumps(message)` for every connected client causes O(N) redundant serialization overhead which blocks the event loop. Also, preventing one client's error from failing the entire broadcast is a good code health standard.
📊 Impact: Reduces serialization cost from O(N) to O(1) relative to connection count, saving CPU cycles and reducing event loop lag.
🔬 Measurement: Can be verified by measuring CPU usage during high-frequency broadcasts with multiple connected clients.

---
*PR created automatically by Jules for task [1760763926462145647](https://jules.google.com/task/1760763926462145647) started by @hana89088*