### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-05 - WebSocket Broadcast Optimization
+**Learning:** In the Python backend, `json.dumps` was being called inside a list comprehension for every connected client during broadcasts, introducing redundant O(N) serialization overhead.
+**Action:** Extract JSON serialization outside the loop so it computes exactly once per broadcast. Use `return_exceptions=True` in `asyncio.gather` to prevent one failing connection from breaking the entire awaitable.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt Optimization: Serialize JSON once instead of O(N) times per client
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What:
Extracted the `json.dumps()` call outside of the `[client.send(...) for client in self.clients]` comprehension in the `broadcast` method. Also added `return_exceptions=True` to `asyncio.gather`.

🎯 Why:
To prevent computing identical JSON strings for each connected client, avoiding redundant O(N) serialization overhead. Returning exceptions prevents a single disconnection failure from breaking the loop.

📊 Impact:
Saves CPU cycles proportional to the number of clients during every broadcast operation. Keeps time complexity for serialization to O(1) relative to connection count.

🔬 Measurement:
Can be verified by broadcasting to 100+ simulated clients and profiling the execution time of the `broadcast` function vs baseline.

---
*PR created automatically by Jules for task [14189824430792641572](https://jules.google.com/task/14189824430792641572) started by @hana89088*