### PR TITLE
⚡ Bolt: Optimize WebSocket broadcast serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimize WebSocket broadcast serialization
+**Learning:** During WebSocket broadcasts, calling `json.dumps()` inside a list comprehension for `asyncio.gather` serializes the identical message once per client. This creates redundant O(N) serialization overhead, which can bottleneck the event loop as connection count grows.
+**Action:** Extract JSON serialization out of broadcast loops to compute it exactly once. Additionally, use `return_exceptions=True` with `asyncio.gather` for concurrent client operations to prevent one disconnection error from failing the entire awaitable.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Serialize JSON exactly once to avoid redundant O(N) overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
### 💡 What
Extracted `json.dumps()` out of the client iteration loop in the `broadcast` method so that the message is serialized exactly once instead of N times. Added `return_exceptions=True` to `asyncio.gather`.

### 🎯 Why
Serializing the identical JSON payload inside the list comprehension created unnecessary O(N) CPU overhead. If 100 clients are connected, the same dictionary was being serialized 100 times. Extracting it reduces CPU load on the event loop. Adding `return_exceptions=True` prevents a single failing client connection from interrupting the broadcast to others.

### 📊 Impact
Reduces CPU overhead for broadcasts from O(N) to O(1) regarding JSON serialization, making broadcasts to multiple clients faster and more resilient.

### 🔬 Measurement
This can be measured by benchmarking the time taken to construct the awaitables and by observing the broadcast latency across a large number of connected clients.

---
*PR created automatically by Jules for task [3367267599186840569](https://jules.google.com/task/3367267599186840569) started by @hana89088*