### PR TITLE
⚡ Bolt: Extract JSON serialization from WebSocket broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Broadcast Serialization Overhead
+**Learning:** In the Python backend's WebSocket broadcast logic, serializing JSON inside the `asyncio.gather` list comprehension causes O(N) redundant serializations and blocks the event loop for each client.
+**Action:** Always serialize the payload exactly once before passing it to broadcast loops or list comprehensions, and use `return_exceptions=True` in `asyncio.gather` to prevent one failing connection from dropping the broadcast.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Compute JSON serialization exactly once to avoid redundant O(N) overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps` outside the `asyncio.gather` list comprehension in the WebSocket `broadcast` method, and added `return_exceptions=True` to the gather call.
🎯 Why: Serializing the exact same JSON message for every connected client inside the list comprehension caused redundant O(N) overhead and event loop blocking. 
📊 Impact: Serialization time becomes O(1) relative to connection count, preventing redundant computation. Adding `return_exceptions=True` prevents a single disconnected client's error from failing the entire broadcast operation for others.
🔬 Measurement: Observe CPU load and latency profiling during broadcasts to multiple connected clients.

---
*PR created automatically by Jules for task [2531767263309138290](https://jules.google.com/task/2531767263309138290) started by @hana89088*