### PR TITLE
⚡ Bolt: Optimize WebSocket broadcasts by extracting JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-24 - Redundant JSON Serialization in WebSocket Broadcasts
+**Learning:** In the Python backend, computing `json.dumps()` inside a list comprehension for `asyncio.gather` during WebSocket broadcasts causes redundant O(N) serialization overhead, which can stutter the asyncio event loop when dealing with many concurrent connections.
+**Action:** Always compute JSON serialization exactly once before broadcasting to multiple WebSocket clients to achieve O(1) serialization overhead.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,12 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # OPTIMIZATION: Serialize JSON exactly once before the loop to avoid redundant O(N) serialization overhead
+            # Expected impact: O(1) serialization instead of O(N), maintaining low latency for large numbers of connected clients
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extract JSON serialization outside the client loop in the `broadcast` method. Include `return_exceptions=True` for `asyncio.gather` to prevent one client's error from failing the broadcast.
🎯 Why: Computing `json.dumps` per client causes O(N) redundant serialization overhead which can block the asyncio event loop when dealing with many connections.
📊 Impact: Reduces JSON serialization overhead from O(N) to O(1), improving broadcast latency and saving CPU cycles under heavy load.
🔬 Measurement: Benchmarking JSON serialization in a loop vs single computation. The event loop lag will be noticeably reduced during broadcasts.

---
*PR created automatically by Jules for task [5908046899096862373](https://jules.google.com/task/5908046899096862373) started by @hana89088*