### PR TITLE
⚡ Bolt: Optimize JSON serialization in WebSocket broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-10 - WebSocket Broadcast Optimization
+**Learning:** In the Python backend's `broadcast` function, JSON serialization inside the list comprehension for `asyncio.gather` causes redundant O(N) serialization overhead relative to connection count.
+**Action:** Always compute JSON serialization exactly once outside of broadcast loops and use `return_exceptions=True` with `asyncio.gather` to maintain O(1) latency and prevent fast-failing.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # Bolt: Serialize once to avoid O(N) serialization overhead
+            serialized_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(serialized_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Moved JSON serialization out of the `asyncio.gather` list comprehension and added `return_exceptions=True` in `broadcast`.
🎯 Why: To avoid redundant O(N) serialization overhead for each connected client and to prevent one client's connection error from interrupting the broadcast.
📊 Impact: Reduces broadcast serialization time to O(1) and improves resilience against connection drops.
🔬 Measurement: Check the CPU usage during high-load broadcasts with multiple clients. The broadcast latency should remain stable as client count increases.

---
*PR created automatically by Jules for task [13266731670281195552](https://jules.google.com/task/13266731670281195552) started by @hana89088*