### PR TITLE
⚡ Bolt: Extract JSON serialization from broadcast loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Broadcast JSON Serialization Overhead
+**Learning:** In WebSocket broadcasts, calling `json.dumps` inside a list comprehension for `asyncio.gather` causes redundant O(N) serialization overhead, which can lag the event loop when many clients are connected.
+**Action:** Always extract JSON serialization out of broadcast loops to compute it exactly once, and use `return_exceptions=True` with `asyncio.gather` so one failing client doesn't abort the broadcast.

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -95,8 +95,11 @@ class AIAssistant:
     async def broadcast(self, message):
         """Broadcast message to all connected clients"""
         if self.clients:
+            # ⚡ Bolt: Extract JSON serialization out of broadcast loop to avoid O(N) overhead
+            encoded_message = json.dumps(message)
             await asyncio.gather(
-                *[client.send(json.dumps(message)) for client in self.clients]
+                *[client.send(encoded_message) for client in self.clients],
+                return_exceptions=True
             )
             
     def start_voice_recognition(self):


### PR DESCRIPTION
💡 What: Extracted `json.dumps` from the list comprehension in `AIAssistant.broadcast` and added `return_exceptions=True` to `asyncio.gather`.
🎯 Why: Redundant JSON serialization inside the broadcast loop caused unnecessary O(N) processing time. `return_exceptions=True` prevents the entire broadcast from failing if one client disconnects unexpectedly.
📊 Impact: Reduces broadcast serialization latency from O(N) to O(1), improving event loop responsiveness under high client load.
🔬 Measurement: Measure average event loop lag during concurrent broadcasts with many connected clients.

---
*PR created automatically by Jules for task [823830173145415464](https://jules.google.com/task/823830173145415464) started by @hana89088*